### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Pre-built 64-bit binaries for Linux and Windows can be found on the
 the AUR ([kristforge-bin](https://aur.archlinux.org/packages/kristforge-bin/) or
 [kristforge-git](https://aur.archlinux.org/packages/kristforge-git/)).
 
+**Note**: Linux users must acquire the package 'ocl-icd-opencl-dev' for libOpenCL.so. Upon installation, libOpenCL.so should be located in '/usr/lib/x86_64-linux-gnu/libOpenCL.so'
+
 ## Usage
 
 Kristforge supports both CPU and GPU mining. GPU mining is usually faster and more efficient, but modern CPUs can also


### PR DESCRIPTION
I've added a bit in the README.md, pertaining to the (potential) absence of libOpenCL.so on Linux systems.
Tested on Ubuntu 20.04 (Debian), so I am not sure of other distros.

https://gyazo.com/ffbedc0584638b5e55a733312a932cd4 <- Console log in question.

Of course, edit the line to your liking, but I think that this information could be very useful for many users.
I wasn't sure if I should have written the package manager format, e.g. 'sudo apt-get install ocl-icd-opencl-dev', but perhaps this would be a good addition.

Please forgive me if I missed a pull request format, this is my first pull request; regardless, I feel like this is pertinent information. :)
Thanks for making kristforge, and for your contribution to open source software,
Fisher.